### PR TITLE
Add BLAS and LAPACK dependencies to host

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   host:
     - pip
     - python
+    - libblas
+    - liblapack
   run:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION
This PR adds `libblas` and `liblapack` dependencies to `host` section.