### PR TITLE
Add m2w64-toolchain to install on windows.

### DIFF
--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -14,6 +14,10 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.7.____73_pypy.yaml
@@ -14,6 +14,10 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -14,6 +14,10 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -14,6 +14,10 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -14,6 +14,10 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.7.____73_pypy.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -12,6 +12,10 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_python3.6.____cpython.yaml
+++ b/.ci_support/win_64_python3.6.____cpython.yaml
@@ -1,11 +1,15 @@
-c_compiler:
-- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- vs2017
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -1,11 +1,15 @@
-c_compiler:
-- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- vs2017
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -1,11 +1,15 @@
-c_compiler:
-- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- vs2017
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,11 +1,15 @@
-c_compiler:
-- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- vs2017
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   patches:
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - aesara-cache = bin.aesara_cache:main
   script: {{ PYTHON }} -m pip install . -vv
@@ -27,6 +27,7 @@ requirements:
   run:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - m2w64-toolchain [win]
     - python
     - setuptools
     - six >=1.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,10 @@ requirements:
     - libblas
     - liblapack
   run:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - m2w64-toolchain [win]
+    - {{ compiler('c') }}  # [unix]
+    - {{ compiler('cxx') }}  # [unix]
+    - {{ compiler('m2w64_c') }}  # [win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - python
     - setuptools
     - six >=1.9.0


### PR DESCRIPTION
It seems like otherwise, no usable c++ compiler gets installed. I was hoping that `- {{ compiler('cxx') }}` would take care of that but it seems like that is only installing `vs2017` or `vs2019`, which do not seem to work with `aesara`.