### PR TITLE
Test warnings with setuptools-based get_info

### DIFF
--- a/recipe/allowed-warnings-base.txt
+++ b/recipe/allowed-warnings-base.txt
@@ -6,26 +6,8 @@ cblas.h: No such file or directory
 Using NumPy C-API based implementation for BLAS functions
 g\+\+ not detected
 
-# Confirmation that these warnings are safe to ignore:
-#     <https://github.com/conda-forge/aesara-feedstock/pull/68#issuecomment-1147759275>
-# Note: hopefully these warnings can be resolved with:
-#     <https://github.com/aesara-devs/aesara/pull/980>
-
-Could not locate executable g77
-Could not locate executable f77
-Could not locate executable ifort
-Could not locate executable ifl
-Could not locate executable f90
-Could not locate executable efl
-
 # These warnings arise on Windows, and don't seem to be confirmed yet as okay:
 g\+\+ not available
-Could not locate executable gfortran
-Could not locate executable f95
-Could not locate executable g95
-Could not locate executable efort
-Could not locate executable efc
-Could not locate executable flang
 don't know how to compile Fortran code on platform 'nt'
 
 # These appear in Linux:

--- a/recipe/allowed-warnings-main.txt
+++ b/recipe/allowed-warnings-main.txt
@@ -1,14 +1,3 @@
 # A list of regex for allowed warnings to ignore during testing of "aesara".
 
 --disable-werror
-
-# Confirmation that these warnings are safe to ignore:
-#     <https://github.com/conda-forge/aesara-feedstock/pull/68#issuecomment-1147759275>
-# Note: hopefully these warnings can be resolved with:
-#     <https://github.com/aesara-devs/aesara/pull/980>
-Could not locate executable g77
-Could not locate executable f77
-Could not locate executable ifort
-Could not locate executable ifl
-Could not locate executable f90
-Could not locate executable efl

--- a/recipe/check-for-warnings.py
+++ b/recipe/check-for-warnings.py
@@ -16,7 +16,7 @@ ALLOWED_WARNINGS = [
 ]
 
 result = subprocess.check_output(
-    ["python", "-c", "import aesara.configdefaults"],
+    ["python", "-c", "import aesara.configdefaults; import aesara.tensor"],
     stderr=subprocess.STDOUT
 )
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/username/reponame/archive/{{ version }}.tar.gz
+  url: https://github.com/aesara-devs/aesara/archive/{{ version }}.tar.gz
   sha256: 571851617663002cea2d0faed6d1fdcc44a99a2870e521885b3ee57152d0b233
   patches:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "2.7.7" %}
+{% set version = "be222f0" %}
 
 package:
   name: aesara-suite  # https://github.com/conda/conda-build/issues/3933
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/a/aesara/aesara-{{ version }}.tar.gz
-  sha256: 8f7465bc0f48cda86c2cefda28372304b200983b3dd3c9b3bc74e234d496e4ef
+  url: https://github.com/username/reponame/archive/{{ version }}.tar.gz
+  sha256: 571851617663002cea2d0faed6d1fdcc44a99a2870e521885b3ee57152d0b233
   patches:
 
 build:


### PR DESCRIPTION
Check for warnings as per https://github.com/aesara-devs/aesara/pull/980#issuecomment-1182502124

The warnings are already in `allowed-warnings-*.txt`, so we have to check the Windows CI logs.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
