### PR TITLE
Revert "Add build and host dependencies" (#124)

### DIFF
--- a/.scripts/create_conda_build_artifacts.bat
+++ b/.scripts/create_conda_build_artifacts.bat
@@ -54,8 +54,8 @@ if defined BLD_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
-        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
+        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> %GITHUB_OUTPUT%
+        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> %GITHUB_OUTPUT%
     )
 )
 
@@ -74,7 +74,7 @@ if defined ENV_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
-        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
+        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> %GITHUB_OUTPUT%
+        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> %GITHUB_OUTPUT%
     )
 )

--- a/.scripts/create_conda_build_artifacts.bat
+++ b/.scripts/create_conda_build_artifacts.bat
@@ -54,8 +54,8 @@ if defined BLD_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> %GITHUB_OUTPUT%
-        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> %GITHUB_OUTPUT%
+        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
+        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
     )
 )
 
@@ -74,7 +74,7 @@ if defined ENV_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> %GITHUB_OUTPUT%
-        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> %GITHUB_OUTPUT%
+        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
+        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
     )
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   patches:
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: aesara-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,19 +24,9 @@ outputs:
       build:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - cython                                 # [build_platform != target_platform]
-        - numpy >=1.17.0                         # [build_platform != target_platform]
-        - setuptools-scm                         # [build_platform != target_platform]
-        - tomli                                  # [build_platform != target_platform]
-        - setuptools >=61.2                      # [build_platform != target_platform]
       host:
         - pip
         - python
-        - cython
-        - numpy >=1.17.0
-        - setuptools-scm
-        - tomli
-        - setuptools >=61.2
       run:
         - python
 


### PR DESCRIPTION
Closes #128

I'm not sure exactly what's causing the second numpy dependency, but for the moment let's revert #124 since that was not obligatory.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
